### PR TITLE
add package site/source code urls

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,10 @@
 url: https://crumplab.com/midiblender
+repo:
+  url:
+    home: https://crumplab.com/midiblender/
+    source: https://github.com/CrumpLab/midiblender/tree/main/
+    issue: https://github.com/CrumpLab/midiblender/issues/
+
 template:
   bootstrap: 5
   params:


### PR DESCRIPTION
I didn't check but I believe this will auto-generate links on your package function reference sites e.g. at
https://www.crumplab.com/midiblender/reference/add_bars_to_copy_df.html
this will add a line below the title

"Source: ..." 

with a link to the source code of that function
and probably other auto-generated links on your site too...